### PR TITLE
Constants: Let's use our bootleg prop

### DIFF
--- a/src/com/bootleggers/shishuota/misc/Constants.java
+++ b/src/com/bootleggers/shishuota/misc/Constants.java
@@ -36,7 +36,7 @@ public final class Constants {
     public static final String PROP_BUILD_DATE = "ro.build.date.utc";
     public static final String PROP_BUILD_VERSION = "ro.bootleggers.version_number";
     public static final String PROP_BUILD_VERSION_INCREMENTAL = "ro.build.version.incremental";
-    public static final String PROP_DEVICE = "ro.product.device";
+    public static final String PROP_DEVICE = "ro.bootleggers.device";
     public static final String PROP_NEXT_DEVICE = "ro.updater.next_device";
     public static final String PROP_RELEASE_TYPE = "ro.bootleggers.releasetype";
     public static final String PROP_UPDATER_ALLOW_DOWNGRADING = "lineage.updater.allow_downgrading";


### PR DESCRIPTION
TEST:
> with ro.product.device it'll show up the actual variant of the device, and it's stinky (example: it shows surnia_umts instead of surnia) so, with this change it'll show up "surnia"